### PR TITLE
Skip unknown key values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,7 @@ fn parse_colours(state: &mut ParseState) -> Result<ColoursSection> {
                 section.slider_border = parse_colour(v)?
             }
 
-            Some(_) => return Err(state.syntax_error("Unknown key value")),
+            Some(_) => {},
 
             _ => break,
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -117,6 +117,7 @@ macro_rules! parse_kv_section {
                             .wrap_syntax_error(value_parser!(v, $($f),*))?
                     },
                     )*
+                    Some(_) => {},
                     _ => break,
                 }
             }


### PR DESCRIPTION
I've noticed that in rare cases a mapper will include a silly value in the key value pair sections. The official game client accepts these (ranked!) maps so we probably should too.